### PR TITLE
Register the Dropwizard Environment as Spring bean named "dw-environment"

### DIFF
--- a/src/main/java/com/github/nhuray/dropwizard/spring/SpringBundle.java
+++ b/src/main/java/com/github/nhuray/dropwizard/spring/SpringBundle.java
@@ -84,6 +84,9 @@ public class SpringBundle<T extends Configuration> implements ConfiguredBundle<T
         // Register a placeholder to resolve Dropwizard Configuration as properties.
         if (placeholderConfigurer != null) registerPlaceholder(configuration, context);
 
+        // Register the Dropwizard environment
+        registerEnvironment(environment, context);
+
         // Refresh context if is not active
         if (!context.isActive()) context.refresh();
 
@@ -263,4 +266,15 @@ public class SpringBundle<T extends Configuration> implements ConfiguredBundle<T
     }
 
 
+    /**
+     * Register Dropwizard Configuration as a Bean Spring.
+     *
+     * @param environment Dropwizard {@link Environment}
+     * @param context     Spring application context
+     */
+    private void registerEnvironment(Environment environment, ConfigurableApplicationContext context) {
+        ConfigurableListableBeanFactory beanFactory = context.getBeanFactory();
+        beanFactory.registerSingleton("dw-environment", environment);
+        LOG.info("Registering Dropwizard Environment under name : dw-environment");
+    }
 }

--- a/src/test/java/com/github/nhuray/dropwizard/spring/SpringBundleTest.java
+++ b/src/test/java/com/github/nhuray/dropwizard/spring/SpringBundleTest.java
@@ -17,6 +17,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.verify;
@@ -31,9 +32,11 @@ public class SpringBundleTest {
 
     private SpringBundle bundle;
 
+    private AnnotationConfigApplicationContext context;
+
     @Before
     public void setup() {
-        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        context = new AnnotationConfigApplicationContext();
         context.scan("hello");
         bundle = new SpringBundle(context, true, true);
 
@@ -119,5 +122,14 @@ public class SpringBundleTest {
         // When
         AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext("test"); // active context
         bundle = new SpringBundle(context, false, true);
+    }
+
+    @Test
+    public void registerEnvironment() throws Exception {
+        // When
+        bundle.run(configuration, environment);
+
+        // Then
+        assertThat(context.getBean("dw-environment"), instanceOf(Environment.class));
     }
 }


### PR DESCRIPTION
Sometimes it's useful to have access to the Dropwizard Environment descriptor from inside another class. To facilitate access to the environment the SpringBundle now registers a singleton named "dw-environment" which is being registered in the `SpringBundle#run()` method.
