### PR TITLE
Obtain ObjectMapper from the Dropwizard Environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ The current version of the project is **0.2**.
 
 | dropwizard-spring  | Dropwizard   | Spring        |
 |:------------------:|:------------:|:-------------:|
-| master (0.2)       | 0.6.0        | 3.1.3.RELEASE |
+| master (0.3.1)     | 0.6.2        | 3.1.4.RELEASE |
+| 0.2                | 0.6.0        | 3.1.3.RELEASE |
 | 0.1                | 0.5.1        | 3.1.1.RELEASE |
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,8 @@
 
 
     <properties>
-        <dropwizard.version>0.6.0</dropwizard.version>
-        <spring.version>3.1.3.RELEASE</spring.version>
+        <dropwizard.version>0.6.2</dropwizard.version>
+        <spring.version>3.1.4.RELEASE</spring.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,21 +7,26 @@
     </parent>
     <groupId>com.github.nhuray</groupId>
     <artifactId>dropwizard-spring</artifactId>
-    <version>0.3-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Dropwizard/Spring integration</name>
     <description>Dropwizard/Spring integration</description>
 
     <scm>
-        <connection>scm:git:git@github.com:nhuray/dropwizard-spring.git</connection>
-        <url>git@github.com:nhuray/dropwizard-spring</url>
-        <developerConnection>scm:git:git@github.com:nhuray/dropwizard-spring.git</developerConnection>
+        <connection>scm:git:git@github.com:41quickbuild/dropwizard-spring.git</connection>
+        <url>git@github.com:41quickbuild/dropwizard-spring</url>
+        <developerConnection>scm:git:git@github.com:41quickbuild/dropwizard-spring.git</developerConnection>
     </scm>
 
     <issueManagement>
-        <system>GitHub</system>
-        <url>https://github.com/nhuray/dropwizard-spring/issues</url>
+      <system>JIRA</system>
+      <url>http://jira</url>
     </issueManagement>
+
+    <ciManagement>
+      <system>Bamboo</system>
+      <url>http://bamboo/bamboo</url>
+    </ciManagement>
 
     <licenses>
         <license>
@@ -40,6 +45,16 @@
         </developer>
     </developers>
 
+    <distributionManagement>
+      <repository>
+        <id>nexus</id>
+        <url>http://nexus.the41.internal/content/repositories/releases/</url>
+      </repository>
+      <snapshotRepository>
+        <id>nexus</id>
+        <url>http://nexus.the41.internal/content/repositories/snapshots/</url>
+      </snapshotRepository>
+    </distributionManagement>
 
     <properties>
         <dropwizard.version>0.6.2</dropwizard.version>

--- a/src/main/java/com/github/nhuray/dropwizard/spring/SpringBundle.java
+++ b/src/main/java/com/github/nhuray/dropwizard/spring/SpringBundle.java
@@ -95,7 +95,7 @@ public class SpringBundle<T extends Configuration> implements ConfiguredBundle<T
         if (registerEnvironment) registerEnvironment(environment, context);
 
         // Register a placeholder to resolve Dropwizard Configuration as properties.
-        if (placeholderConfigurer != null) registerPlaceholder(configuration, context);
+        if (placeholderConfigurer != null) registerPlaceholder(environment, configuration, context);
 
         // Refresh context if is not active
         if (!context.isActive()) context.refresh();
@@ -286,8 +286,9 @@ public class SpringBundle<T extends Configuration> implements ConfiguredBundle<T
      * @param configuration Dropwizard configuration
      * @param context       spring application context
      */
-    private void registerPlaceholder(T configuration, ConfigurableApplicationContext context) {
+    private void registerPlaceholder(Environment environment, T configuration, ConfigurableApplicationContext context) {
         ConfigurableListableBeanFactory beanFactory = context.getBeanFactory();
+        placeholderConfigurer.setObjectMapper(environment.getObjectMapperFactory().build());
         placeholderConfigurer.setConfiguration(configuration);
         beanFactory.registerSingleton(PLACEHOLDER_BEAN_NAME, placeholderConfigurer);
         LOG.info("Registering Dropwizard Placeholder under name : " + PLACEHOLDER_BEAN_NAME);

--- a/src/main/java/com/github/nhuray/dropwizard/spring/config/ConfigurationPlaceholderConfigurer.java
+++ b/src/main/java/com/github/nhuray/dropwizard/spring/config/ConfigurationPlaceholderConfigurer.java
@@ -31,9 +31,9 @@ public class ConfigurationPlaceholderConfigurer implements BeanFactoryPostProces
 
     private Configuration configuration;
 
-    private ObjectMapper mapper = new ObjectMapper();
+    private ObjectMapper objectMapper;
 
-    private PropertiesPersister propertiesPersister = new JsonPropertiesPersister(mapper);
+    private PropertiesPersister propertiesPersister;
 
     // ~ Copied from {@link PlaceholderConfigurerSupport} ----------------------------------------------------------------------
 
@@ -85,7 +85,7 @@ public class ConfigurationPlaceholderConfigurer implements BeanFactoryPostProces
      */
     private void loadProperties(Properties props) throws BeansException, IOException {
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
-        mapper.writeValue(stream, configuration);
+        objectMapper.writeValue(stream, configuration);
         propertiesPersister.load(props, new ByteArrayInputStream(stream.toByteArray()));
     }
 
@@ -157,6 +157,10 @@ public class ConfigurationPlaceholderConfigurer implements BeanFactoryPostProces
         this.configuration = configuration;
     }
 
+    public void setObjectMapper(final ObjectMapper objectMapper) {
+      this.objectMapper = objectMapper;
+      this.propertiesPersister = new JsonPropertiesPersister(objectMapper);
+    }
 
     // ~ Copied from {@link PropertyPlaceholderConfigurer} ----------------------------------------------------------------------
 

--- a/src/test/java/com/github/nhuray/dropwizard/spring/SpringBundleTest.java
+++ b/src/test/java/com/github/nhuray/dropwizard/spring/SpringBundleTest.java
@@ -1,7 +1,9 @@
 package com.github.nhuray.dropwizard.spring;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yammer.dropwizard.config.Configuration;
 import com.yammer.dropwizard.config.Environment;
+import com.yammer.dropwizard.json.ObjectMapperFactory;
 import com.yammer.dropwizard.tasks.Task;
 import com.yammer.metrics.core.HealthCheck;
 import hello.config.HelloAppConfiguration;
@@ -22,12 +24,15 @@ import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.verify;
-
+import static org.mockito.Mockito.when;
 
 public class SpringBundleTest {
 
     @Mock
     private Environment environment;
+
+    @Mock
+    private ObjectMapperFactory objectMapperFactory;
 
     private HelloAppConfiguration configuration;
 
@@ -48,6 +53,9 @@ public class SpringBundleTest {
 
         configuration = new HelloAppConfiguration();
         configuration.setHello(hello);
+
+        when(environment.getObjectMapperFactory()).thenReturn(objectMapperFactory);
+        when(objectMapperFactory.build()).thenReturn(new ObjectMapper());
     }
 
     @Test

--- a/src/test/java/com/github/nhuray/dropwizard/spring/config/ConfigurationPlaceholderConfigurerTest.java
+++ b/src/test/java/com/github/nhuray/dropwizard/spring/config/ConfigurationPlaceholderConfigurerTest.java
@@ -2,6 +2,7 @@ package com.github.nhuray.dropwizard.spring.config;
 
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yammer.dropwizard.config.Configuration;
 import org.junit.Before;
 import org.junit.Test;
@@ -37,6 +38,7 @@ public class ConfigurationPlaceholderConfigurerTest {
                 rootBeanDefinition(ConfigurationTestBean.class)
                         .addPropertyValue("connectorType", "${http.connectorType}")
                         .getBeanDefinition());
+        placeholder.setObjectMapper(new ObjectMapper());
 
         // When
         placeholder.postProcessBeanFactory(bf);
@@ -59,6 +61,7 @@ public class ConfigurationPlaceholderConfigurerTest {
                         .addPropertyValue("connectorType", "@<http.connectorType>")
                         .addPropertyValue("rootPath", "${key2}")
                         .getBeanDefinition());
+        placeholder.setObjectMapper(new ObjectMapper());
 
         // When
         placeholder.postProcessBeanFactory(bf);
@@ -80,6 +83,7 @@ public class ConfigurationPlaceholderConfigurerTest {
                 rootBeanDefinition(ConfigurationTestBean.class)
                         .addPropertyValue("connectorType", "${nullProperty}")
                         .getBeanDefinition());
+        placeholder.setObjectMapper(new ObjectMapper());
 
         // When
         placeholder.postProcessBeanFactory(bf);


### PR DESCRIPTION
In your existing code, the ObjectMapper is hard-wired to a new one created in ConfigurationPlaceholderConfigurer instead of relying on the ObjectMapperFactory in the Dropwizard Environment.  This change makes the ConfigurationPlaceholderConfigurer use an ObjectMapper obtained from the Dropwizard Environment.
