### PR TITLE
upgrade to dropwizard 0.7.0-rc1

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The current version of the project is **0.2**.
 
 | dropwizard-spring  | Dropwizard   | Spring        |
 |:------------------:|:------------:|:-------------:|
+| master (0.3.2)     | 0.7.0-rc1    | 3.1.4.RELEASE |
 | master (0.3.1)     | 0.6.2        | 3.1.4.RELEASE |
 | 0.2                | 0.6.0        | 3.1.3.RELEASE |
 | 0.1                | 0.5.1        | 3.1.1.RELEASE |

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     </distributionManagement>
 
     <properties>
-        <dropwizard.version>0.6.2</dropwizard.version>
+        <dropwizard.version>0.7.0-rc1</dropwizard.version>
         <spring.version>3.1.4.RELEASE</spring.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
@@ -66,7 +66,7 @@
 
         <!-- Compile Dependencies -->
         <dependency>
-            <groupId>com.yammer.dropwizard</groupId>
+            <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
             <version>${dropwizard.version}</version>
             <optional>true</optional>

--- a/src/main/java/com/github/nhuray/dropwizard/spring/SpringContextManaged.java
+++ b/src/main/java/com/github/nhuray/dropwizard/spring/SpringContextManaged.java
@@ -1,0 +1,24 @@
+package com.github.nhuray.dropwizard.spring;
+
+import io.dropwizard.lifecycle.Managed;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import io.dropwizard.lifecycle.Managed;
+
+public class SpringContextManaged implements Managed {
+  private final ConfigurableApplicationContext context;
+
+  public SpringContextManaged(final ConfigurableApplicationContext context) {
+    this.context = context;
+  }
+
+  @Override
+  public void start() throws Exception {
+    // do nothing
+  }
+
+  @Override
+  public void stop() throws Exception {
+    context.close();
+  }
+}

--- a/src/main/java/com/github/nhuray/dropwizard/spring/config/ConfigurationPlaceholderConfigurer.java
+++ b/src/main/java/com/github/nhuray/dropwizard/spring/config/ConfigurationPlaceholderConfigurer.java
@@ -1,7 +1,7 @@
 package com.github.nhuray.dropwizard.spring.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.yammer.dropwizard.config.Configuration;
+import io.dropwizard.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;

--- a/src/test/java/com/github/nhuray/dropwizard/spring/SpringBundleTest.java
+++ b/src/test/java/com/github/nhuray/dropwizard/spring/SpringBundleTest.java
@@ -1,11 +1,20 @@
 package com.github.nhuray.dropwizard.spring;
 
+import com.codahale.metrics.health.HealthCheckRegistry;
+import com.codahale.metrics.servlets.HealthCheckServlet;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.yammer.dropwizard.config.Configuration;
-import com.yammer.dropwizard.config.Environment;
-import com.yammer.dropwizard.json.ObjectMapperFactory;
-import com.yammer.dropwizard.tasks.Task;
-import com.yammer.metrics.core.HealthCheck;
+import io.dropwizard.Configuration;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jersey.setup.JerseyEnvironment;
+import io.dropwizard.jetty.setup.ServletEnvironment;
+import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
+import io.dropwizard.setup.AdminEnvironment;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.lifecycle.ServerLifecycleListener;
+import io.dropwizard.servlets.tasks.Task;
+import com.codahale.metrics.health.HealthCheck;
+
+import hello.server_lifecycle_listeners.HelloServerLifecycleListener;
 import hello.config.HelloAppConfiguration;
 import hello.config.HelloConfiguration;
 import hello.health.HelloHealthCheck;
@@ -19,6 +28,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertNotNull;
@@ -32,7 +42,19 @@ public class SpringBundleTest {
     private Environment environment;
 
     @Mock
-    private ObjectMapperFactory objectMapperFactory;
+    private JerseyEnvironment jersey;
+
+    @Mock
+    private AdminEnvironment admin;
+
+    @Mock
+    private ServletEnvironment servlets;
+
+    @Mock
+    private LifecycleEnvironment lifecycle ;
+
+    @Mock
+    private HealthCheckRegistry healthChecks ;
 
     private HelloAppConfiguration configuration;
 
@@ -54,8 +76,17 @@ public class SpringBundleTest {
         configuration = new HelloAppConfiguration();
         configuration.setHello(hello);
 
-        when(environment.getObjectMapperFactory()).thenReturn(objectMapperFactory);
-        when(objectMapperFactory.build()).thenReturn(new ObjectMapper());
+        when(environment.getObjectMapper()).thenReturn(Jackson.newObjectMapper());
+
+        when(environment.jersey()).thenReturn(jersey);
+
+        when(environment.admin()).thenReturn(admin);
+
+        when(environment.servlets()).thenReturn(servlets);
+
+        when(environment.lifecycle()).thenReturn(lifecycle);
+
+        when(environment.healthChecks()).thenReturn(healthChecks);
     }
 
     @Test
@@ -65,7 +96,7 @@ public class SpringBundleTest {
 
         // Then
         ArgumentCaptor<HelloResource> resource = ArgumentCaptor.forClass(HelloResource.class);
-        verify(environment).addResource(resource.capture());
+        verify(jersey).register(resource.capture());
         assertThat(resource.getValue(), is(HelloResource.class));
     }
 
@@ -76,7 +107,10 @@ public class SpringBundleTest {
 
         // Then
         ArgumentCaptor<? extends HealthCheck> healthCheck = ArgumentCaptor.forClass(HealthCheck.class);
-        verify(environment).addHealthCheck(healthCheck.capture());
+        ArgumentCaptor<String> healthCheckName = ArgumentCaptor.forClass(String.class);
+        verify(healthChecks).register(healthCheckName.capture(), healthCheck.capture());
+
+        assertThat(healthCheckName.getValue(), is("helloHealthCheck")); // is the bean name
         assertThat(healthCheck.getValue(), is(HelloHealthCheck.class));
     }
 
@@ -87,8 +121,19 @@ public class SpringBundleTest {
 
         // Then
         ArgumentCaptor<? extends Task> task = ArgumentCaptor.forClass(Task.class);
-        verify(environment).addTask(task.capture());
+        verify(admin).addTask(task.capture());
         assertThat(task.getValue(), is(HelloTask.class));
+    }
+
+    @Test
+    public void registerServerLifecycleListener() throws Exception {
+        // When
+        bundle.run(configuration, environment);
+
+        // Then
+        ArgumentCaptor<? extends ServerLifecycleListener> listener = ArgumentCaptor.forClass(ServerLifecycleListener.class);
+        verify(servlets).addServletListeners(listener.capture());
+        assertThat(listener.getValue(), is(HelloServerLifecycleListener.class));
     }
 
     @Test
@@ -98,10 +143,10 @@ public class SpringBundleTest {
 
         // Then
         ArgumentCaptor<HelloResource> resource = ArgumentCaptor.forClass(HelloResource.class);
-        verify(environment).addResource(resource.capture());
+        verify(jersey).register(resource.capture());
 
         HelloResource r = resource.getValue();
-        assertThat(r.getPort(), is(8080)); // Defaut port
+        assertThat(r.getPort(), is(8080)); // Default port
     }
 
     @Test
@@ -121,7 +166,7 @@ public class SpringBundleTest {
 
         // Then
         ArgumentCaptor<HelloResource> resource = ArgumentCaptor.forClass(HelloResource.class);
-        verify(environment).addResource(resource.capture());
+        verify(jersey).register(resource.capture());
 
         HelloResource r = resource.getValue();
         final HelloService helloService = r.getHelloService();

--- a/src/test/java/com/github/nhuray/dropwizard/spring/config/ConfigurationPlaceholderConfigurerTest.java
+++ b/src/test/java/com/github/nhuray/dropwizard/spring/config/ConfigurationPlaceholderConfigurerTest.java
@@ -1,9 +1,10 @@
 package com.github.nhuray.dropwizard.spring.config;
 
 
+import ch.qos.logback.classic.Level;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.yammer.dropwizard.config.Configuration;
+import io.dropwizard.Configuration;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
@@ -36,7 +37,7 @@ public class ConfigurationPlaceholderConfigurerTest {
         DefaultListableBeanFactory bf = new DefaultListableBeanFactory();
         bf.registerBeanDefinition("testBean",
                 rootBeanDefinition(ConfigurationTestBean.class)
-                        .addPropertyValue("connectorType", "${http.connectorType}")
+                        .addPropertyValue("loggingLevel", "${logging.level.levelStr}")
                         .getBeanDefinition());
         placeholder.setObjectMapper(new ObjectMapper());
 
@@ -45,7 +46,7 @@ public class ConfigurationPlaceholderConfigurerTest {
 
         // Then
         ConfigurationTestBean bean = bf.getBean(ConfigurationTestBean.class);
-        assertThat(bean.getConnectorType(), equalTo("blocking"));
+        assertThat(bean.getLoggingLevel(), equalTo(Level.INFO));
     }
 
     @Test
@@ -58,7 +59,7 @@ public class ConfigurationPlaceholderConfigurerTest {
         DefaultListableBeanFactory bf = new DefaultListableBeanFactory();
         bf.registerBeanDefinition("testBean",
                 rootBeanDefinition(ConfigurationTestBean.class)
-                        .addPropertyValue("connectorType", "@<http.connectorType>")
+                        .addPropertyValue("loggingLevel", "@<logging.level.levelStr>")
                         .addPropertyValue("rootPath", "${key2}")
                         .getBeanDefinition());
         placeholder.setObjectMapper(new ObjectMapper());
@@ -68,7 +69,7 @@ public class ConfigurationPlaceholderConfigurerTest {
 
         // Then
         ConfigurationTestBean bean = bf.getBean(ConfigurationTestBean.class);
-        assertThat(bean.getConnectorType(), is("blocking"));
+        assertThat(bean.getLoggingLevel(), is(Level.INFO));
         assertThat(bean.getRootPath(), is("${key2}"));
     }
 

--- a/src/test/java/com/github/nhuray/dropwizard/spring/config/ConfigurationTestBean.java
+++ b/src/test/java/com/github/nhuray/dropwizard/spring/config/ConfigurationTestBean.java
@@ -1,9 +1,13 @@
 package com.github.nhuray.dropwizard.spring.config;
 
+import ch.qos.logback.classic.Level;
+
 public class ConfigurationTestBean {
 
     private String connectorType;
     private String rootPath;
+
+    private Level loggingLevel;
 
     public String getConnectorType() {
         return connectorType;
@@ -19,5 +23,13 @@ public class ConfigurationTestBean {
 
     public void setRootPath(String rootPath) {
         this.rootPath = rootPath;
+    }
+
+    public Level getLoggingLevel() {
+        return loggingLevel;
+    }
+
+    public void setLoggingLevel(Level loggingLevel) {
+        this.loggingLevel = loggingLevel;
     }
 }

--- a/src/test/java/hello/HelloApp.java
+++ b/src/test/java/hello/HelloApp.java
@@ -3,16 +3,17 @@ package hello;
 
 import com.github.nhuray.dropwizard.spring.SpringBundle;
 import com.github.nhuray.dropwizard.spring.config.ConfigurationPlaceholderConfigurer;
-import com.yammer.dropwizard.Service;
-import com.yammer.dropwizard.config.Bootstrap;
-import com.yammer.dropwizard.config.Environment;
+import io.dropwizard.Application;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
 import hello.config.HelloAppConfiguration;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import sun.misc.Service;
 
-public class HelloApp extends Service<HelloAppConfiguration> {
+public class HelloApp extends Application<HelloAppConfiguration> {
 
     private static final String CONFIGURATION_FILE = "src/test/resources/hello/hello.yml";
 

--- a/src/test/java/hello/config/HelloAppConfiguration.java
+++ b/src/test/java/hello/config/HelloAppConfiguration.java
@@ -1,7 +1,7 @@
 package hello.config;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.yammer.dropwizard.config.Configuration;
+import io.dropwizard.Configuration;
 
 public class HelloAppConfiguration extends Configuration {
 

--- a/src/test/java/hello/config/HelloConfiguration.java
+++ b/src/test/java/hello/config/HelloConfiguration.java
@@ -2,6 +2,7 @@ package hello.config;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import hello.health.HelloHealthCheck;
+import hello.server_lifecycle_listeners.HelloServerLifecycleListener;
 import hello.service.HelloService;
 import hello.tasks.HelloTask;
 import org.springframework.beans.factory.annotation.Value;
@@ -28,6 +29,11 @@ public class HelloConfiguration {
     @Bean
     public HelloHealthCheck helloHealthCheck() {
         return new HelloHealthCheck();
+    }
+
+    @Bean
+    public HelloServerLifecycleListener helloServerLifecycleListener() {
+      return new HelloServerLifecycleListener();
     }
 
     public String getMessage() {

--- a/src/test/java/hello/health/HelloHealthCheck.java
+++ b/src/test/java/hello/health/HelloHealthCheck.java
@@ -1,13 +1,9 @@
 package hello.health;
 
-import com.yammer.metrics.core.HealthCheck;
+import com.codahale.metrics.health.HealthCheck;
 
 public class HelloHealthCheck extends HealthCheck {
 
-	public HelloHealthCheck() {
-		super("hello-health");
-	}
-	
 	@Override
 	protected Result check() throws Exception {
 		return Result.healthy();

--- a/src/test/java/hello/resources/HelloResource.java
+++ b/src/test/java/hello/resources/HelloResource.java
@@ -1,10 +1,8 @@
 package hello.resources;
 
 
-import com.yammer.dropwizard.config.Configuration;
-import com.yammer.dropwizard.config.Environment;
-import com.yammer.dropwizard.config.HttpConfiguration;
-import com.yammer.dropwizard.validation.Validator;
+import io.dropwizard.Configuration;
+import io.dropwizard.setup.Environment;
 import hello.service.HelloService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -21,7 +19,7 @@ public class HelloResource {
     @Autowired
     private HelloService helloService;
 
-    @Value("${http.port}")
+    @Value("${server.applicationConnectors[0].port}")
     private Integer port;
 
     @Value("#{dw}")
@@ -32,7 +30,10 @@ public class HelloResource {
 
     @GET
     public Response doGet() {
-        return Response.ok(String.format("%s<br/>Hello application is running on port : %d; connectorType : %s", helloService.greeting(), port, configuration.getHttpConfiguration().getConnectorType())).build();
+        return Response.ok(String.format("%s<br/>Hello application is running on port : %d;",
+                helloService.greeting(),
+                port)
+        ).build();
     }
 
     public HelloService getHelloService() {

--- a/src/test/java/hello/server_lifecycle_listeners/HelloServerLifecycleListener.java
+++ b/src/test/java/hello/server_lifecycle_listeners/HelloServerLifecycleListener.java
@@ -1,0 +1,12 @@
+package hello.server_lifecycle_listeners;
+
+import org.eclipse.jetty.server.Server;
+
+import io.dropwizard.lifecycle.ServerLifecycleListener;
+
+public class HelloServerLifecycleListener implements ServerLifecycleListener {
+  @Override
+  public void serverStarted(final Server server) {
+    System.out.println("my server started");
+  }
+}

--- a/src/test/java/hello/tasks/HelloTask.java
+++ b/src/test/java/hello/tasks/HelloTask.java
@@ -1,7 +1,7 @@
 package hello.tasks;
 
 import com.google.common.collect.ImmutableMultimap;
-import com.yammer.dropwizard.tasks.Task;
+import io.dropwizard.servlets.tasks.Task;
 
 import java.io.PrintWriter;
 

--- a/src/test/resources/hello/hello.yml
+++ b/src/test/resources/hello/hello.yml
@@ -1,16 +1,9 @@
 # HTTP-specific options.
-http:
+server:
 
-  # The port on which the HTTP server listens for service requests.
-  port: 9898
-
-  # The type of connector to use. Other valid values are "nonblocking" or "legacy". In general, the
-  # blocking connector should be used for low-latency services with short request durations. The
-  # nonblocking connector should be used for services with long request durations or which
-  # specifically take advantage of Jetty's continuation support.
-  # If you need SSL support, you can either choose from "nonblocking+ssl" or "legacy+ssl".
-  connectorType: blocking
-
+  applicationContectors:
+    - type: http
+      port: 9898
 
 hello:
 


### PR DESCRIPTION
This is a completely incompatible update to dropwizard, hence the size of the
changes.
- All of the `Environment` `add*` methods have be moved/replaced by
  `jersey()` and `admin()` etc
- The configuration object is significantly change, hence changes to http.port
  have been change to either server.applicationConnectors[0].port or just replaced
  with logging.level
